### PR TITLE
挂载kvrocks子目录，防止kvrocks初始化配置文件失败

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ services:
     container_name: moontv-kvrocks
     restart: unless-stopped
     volumes:
-      - kvrocks-data:/var/lib/kvrocks
+      - kvrocks-data:/var/lib/kvrocks/data
     networks:
       - moontv-network
 networks:


### PR DESCRIPTION
挂载kvrocks子目录，防止kvrocks初始化配置文件失败