### PR TITLE
Change kvrocks volume path from 'data' to 'db'

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ services:
     container_name: moontv-kvrocks
     restart: unless-stopped
     volumes:
-      - kvrocks-data:/var/lib/kvrocks/data
+      - kvrocks-data:/var/lib/kvrocks/db
     networks:
       - moontv-network
 networks:
@@ -345,7 +345,7 @@ networks:
 volumes:
   kvrocks-data:
 ```
-
+（若指定kvrocks-data目录，需要将所挂载的数据目录权限调整为777否则会导致创建数据库失败）
 ## 配置文件
 
 完成部署后为空壳应用，无播放源，需要站长在管理后台的配置文件设置中填写配置文件，本版本已不支持无数据库运行。

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ services:
     container_name: moontv-kvrocks
     restart: unless-stopped
     volumes:
-      - kvrocks-data:/var/lib/kvrocks/data
+      - kvrocks-data:/var/lib/kvrocks/db
     networks:
       - moontv-network
 networks:
@@ -231,6 +231,7 @@ networks:
 volumes:
   kvrocks-data:
 ```
+（若指定kvrocks-data目录，需要将所挂载的数据目录权限调整为777否则会导致创建数据库失败）
 
 ### SQLite 存储
 


### PR DESCRIPTION
修复使用watchtower自动更新时，由于compose.yml文件路径错误导致的数据丢失问题。

原因：/var/lib/kvrocks/data 应该改为/var/lib/kvrocks/db

若需要挂载指定目录，需将所需目录权限手动调整为777，否则可能会导致创建数据文件失败。