### PR TITLE
fix: 延迟数据库 schema 初始化以解决 Cloudflare 部署构建期报错

### DIFF
--- a/src/app/api/admin/config_file/route.ts
+++ b/src/app/api/admin/config_file/route.ts
@@ -3,7 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getAuthInfoFromCookie } from '@/lib/auth';
-import { getConfig, refineConfig } from '@/lib/config';
+import { getConfig, refineConfig, setCachedConfig } from '@/lib/config';
 import { db } from '@/lib/db';
 
 export const runtime = 'nodejs';
@@ -79,6 +79,7 @@ export async function POST(request: NextRequest) {
     adminConfig = refineConfig(adminConfig);
     // 更新配置文件
     await db.saveAdminConfig(adminConfig);
+    await setCachedConfig(adminConfig);
 
     // 清除短剧视频源缓存（因为配置文件可能包含新的视频源）
     try {

--- a/src/lib/d1.db.ts
+++ b/src/lib/d1.db.ts
@@ -44,7 +44,10 @@ export class D1Storage implements IStorage {
   private _schemaReady: Promise<void> | null = null;
   private get schemaReady(): Promise<void> {
     if (!this._schemaReady) {
-      this._schemaReady = this.ensureMangaShelfColumns();
+      this._schemaReady = this.ensureMangaShelfColumns().catch((err) => {
+        this._schemaReady = null;
+        throw err;
+      });
     }
     return this._schemaReady;
   }

--- a/src/lib/d1.db.ts
+++ b/src/lib/d1.db.ts
@@ -41,12 +41,17 @@ import { userInfoCache } from './user-cache';
  */
 export class D1Storage implements IStorage {
   private db: DatabaseAdapter;
-  private schemaReady: Promise<void>;
+  private _schemaReady: Promise<void> | null = null;
+  private get schemaReady(): Promise<void> {
+    if (!this._schemaReady) {
+      this._schemaReady = this.ensureMangaShelfColumns();
+    }
+    return this._schemaReady;
+  }
   public adapter: RedisHashAdapter;
 
   constructor(adapter: DatabaseAdapter) {
     this.db = adapter;
-    this.schemaReady = this.ensureMangaShelfColumns();
     // 创建 Redis Hash 兼容适配器用于设备管理
     this.adapter = new RedisHashAdapter(adapter);
   }

--- a/src/lib/postgres.db.ts
+++ b/src/lib/postgres.db.ts
@@ -45,7 +45,10 @@ export class PostgresStorage implements IStorage {
   private _schemaReady: Promise<void> | null = null;
   private get schemaReady(): Promise<void> {
     if (!this._schemaReady) {
-      this._schemaReady = this.ensureMangaShelfColumns();
+      this._schemaReady = this.ensureMangaShelfColumns().catch((err) => {
+        this._schemaReady = null;
+        throw err;
+      });
     }
     return this._schemaReady;
   }

--- a/src/lib/postgres.db.ts
+++ b/src/lib/postgres.db.ts
@@ -42,12 +42,17 @@ import {
  */
 export class PostgresStorage implements IStorage {
   private db: DatabaseAdapter;
-  private schemaReady: Promise<void>;
+  private _schemaReady: Promise<void> | null = null;
+  private get schemaReady(): Promise<void> {
+    if (!this._schemaReady) {
+      this._schemaReady = this.ensureMangaShelfColumns();
+    }
+    return this._schemaReady;
+  }
   public adapter: any; // 用于兼容
 
   constructor(adapter: DatabaseAdapter) {
     this.db = adapter;
-    this.schemaReady = this.ensureMangaShelfColumns();
     // 创建一个简单的适配器用于设备管理
     this.adapter = new PostgresRedisHashAdapter(adapter);
   }


### PR DESCRIPTION
### 📖 问题背景
解决在使用 Cloudflare Pages / Workers (OpenNext) 部署时，`pnpm run build:cloudflare`（Next.js 静态预编译阶段）出现以下报错导致构建失败的问题：
> `ERROR: getCloudflareContext has been called in sync mode in either a static route or at the top level of a non-static one`

### 🔍 原因分析
在 `D1Storage` 和 `PostgresStorage` 的构造函数中，原先同步调用了 `this.schemaReady = this.ensureMangaShelfColumns();`。
这导致 Next.js 在构建期静态编译 API 路由导入该模块时，会立即实例化存储并向代理数据库发起 `prepare` 请求，从而在构建环境中触发了 `getCloudflareContext()`。由于构建期没有活的请求上下文，该方法同步调用便会报错。

### 🛠️ 解决方案
将 `schemaReady` 变量改造为惰性加载的属性访问器 (Lazy Getter)。
只有在运行时（有真正请求进来时）调用漫画书架等需要保障表结构完整的方法时，才会触发 `ensureMangaShelfColumns()`。由此避开了 Next.js 编译构建期间对 Cloudflare 运行环境绑定的同步访问。