### PR TITLE
feat: add traffic analytics configuration (Umami/GA/Clarity/Custom)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -24,6 +24,7 @@ import { CSS } from '@dnd-kit/utilities';
 import {
   AlertCircle,
   AlertTriangle,
+  BarChart3,
   BookMarked,
   BookOpen,
   Bot,
@@ -406,6 +407,11 @@ interface SiteConfig {
   OIDCClientId?: string;
   OIDCClientSecret?: string;
   OIDCButtonText?: string;
+  AnalyticsEnabled?: boolean;
+  AnalyticsProvider?: 'umami' | 'google' | 'custom';
+  AnalyticsScriptUrl?: string;
+  AnalyticsWebsiteId?: string;
+  AnalyticsCustomScript?: string;
 }
 
 // 视频源数据类型
@@ -10198,6 +10204,11 @@ const SiteConfigComponent = ({
     OIDCClientId: '',
     OIDCClientSecret: '',
     OIDCButtonText: '',
+    AnalyticsEnabled: false,
+    AnalyticsProvider: 'umami',
+    AnalyticsScriptUrl: '',
+    AnalyticsWebsiteId: '',
+    AnalyticsCustomScript: '',
   });
 
   // 豆瓣数据源相关状态
@@ -11525,6 +11536,170 @@ const SiteConfigComponent = ({
               开启后将显示豆瓣评论与相似推荐。评论为逆向抓取，请自行承担责任。
             </p>
           </div>
+        </div>
+      </details>
+
+      {/* 流量统计配置 */}
+      <details className='group rounded-lg border border-gray-200 p-4 dark:border-gray-700'>
+        <summary className='flex cursor-pointer items-center justify-between font-medium text-gray-900 dark:text-gray-100'>
+          <span className='flex items-center gap-2'>
+            <BarChart3 className='h-5 w-5' />
+            流量统计
+          </span>
+          <ChevronDown className='h-5 w-5 transition-transform group-open:rotate-180' />
+        </summary>
+        <div className='mt-4 space-y-4'>
+          {/* 启用开关 */}
+          <div className='flex items-center justify-between'>
+            <div>
+              <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+                启用流量统计
+              </label>
+              <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
+                开启后将在页面中注入统计脚本，支持 Umami、Google Analytics 和自定义代码
+              </p>
+            </div>
+            <button
+              type='button'
+              onClick={() =>
+                setSiteSettings((prev) => ({
+                  ...prev,
+                  AnalyticsEnabled: !prev.AnalyticsEnabled,
+                }))
+              }
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 ${
+                siteSettings.AnalyticsEnabled
+                  ? buttonStyles.toggleOn
+                  : buttonStyles.toggleOff
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full ${
+                  buttonStyles.toggleThumb
+                } transition-transform ${
+                  siteSettings.AnalyticsEnabled
+                    ? buttonStyles.toggleThumbOn
+                    : buttonStyles.toggleThumbOff
+                }`}
+              />
+            </button>
+          </div>
+
+          {siteSettings.AnalyticsEnabled && (
+            <>
+              {/* 统计服务提供商 */}
+              <div>
+                <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+                  统计服务
+                </label>
+                <select
+                  value={siteSettings.AnalyticsProvider}
+                  onChange={(e) =>
+                    setSiteSettings((prev) => ({
+                      ...prev,
+                      AnalyticsProvider: e.target.value as 'umami' | 'google' | 'custom',
+                    }))
+                  }
+                  className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200'
+                >
+                  <option value='umami'>Umami（开源，自托管）</option>
+                  <option value='google'>Google Analytics</option>
+                  <option value='custom'>自定义代码</option>
+                </select>
+              </div>
+
+              {siteSettings.AnalyticsProvider === 'umami' && (
+                <>
+                  <div>
+                    <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+                      Umami 脚本地址
+                    </label>
+                    <input
+                      type='text'
+                      value={siteSettings.AnalyticsScriptUrl}
+                      onChange={(e) =>
+                        setSiteSettings((prev) => ({
+                          ...prev,
+                          AnalyticsScriptUrl: e.target.value,
+                        }))
+                      }
+                      placeholder='https://your-umami-server.com/script.js'
+                      className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200'
+                    />
+                    <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
+                      Umami 实例的 script.js 完整 URL
+                    </p>
+                  </div>
+                  <div>
+                    <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+                      网站 ID (Website ID)
+                    </label>
+                    <input
+                      type='text'
+                      value={siteSettings.AnalyticsWebsiteId}
+                      onChange={(e) =>
+                        setSiteSettings((prev) => ({
+                          ...prev,
+                          AnalyticsWebsiteId: e.target.value,
+                        }))
+                      }
+                      placeholder='e.g. 12345678-abcd-efgh-ijkl-1234567890ab'
+                      className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200'
+                    />
+                    <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
+                      在 Umami 后台添加网站后获取的 Website ID
+                    </p>
+                  </div>
+                </>
+              )}
+
+              {siteSettings.AnalyticsProvider === 'google' && (
+                <div>
+                  <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+                    Measurement ID
+                  </label>
+                  <input
+                    type='text'
+                    value={siteSettings.AnalyticsWebsiteId}
+                    onChange={(e) =>
+                      setSiteSettings((prev) => ({
+                        ...prev,
+                        AnalyticsWebsiteId: e.target.value,
+                      }))
+                    }
+                    placeholder='G-XXXXXXXXXX'
+                    className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200'
+                  />
+                  <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
+                    Google Analytics 4 的 Measurement ID，在 GA 后台「数据流」中获取
+                  </p>
+                </div>
+              )}
+
+              {siteSettings.AnalyticsProvider === 'custom' && (
+                <div>
+                  <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+                    自定义统计代码
+                  </label>
+                  <textarea
+                    value={siteSettings.AnalyticsCustomScript}
+                    onChange={(e) =>
+                      setSiteSettings((prev) => ({
+                        ...prev,
+                        AnalyticsCustomScript: e.target.value,
+                      }))
+                    }
+                    placeholder='粘贴完整的统计脚本代码，如百度统计、Plausible、51la 等...'
+                    rows={6}
+                    className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200'
+                  />
+                  <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
+                    支持任意第三方统计服务的脚本代码，将直接注入到页面 &lt;head&gt; 中
+                  </p>
+                </div>
+              )}
+            </>
+          )}
         </div>
       </details>
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -408,7 +408,7 @@ interface SiteConfig {
   OIDCClientSecret?: string;
   OIDCButtonText?: string;
   AnalyticsEnabled?: boolean;
-  AnalyticsProvider?: 'umami' | 'google' | 'custom';
+  AnalyticsProvider?: 'umami' | 'google' | 'clarity' | 'custom';
   AnalyticsScriptUrl?: string;
   AnalyticsWebsiteId?: string;
   AnalyticsCustomScript?: string;
@@ -11597,13 +11597,14 @@ const SiteConfigComponent = ({
                   onChange={(e) =>
                     setSiteSettings((prev) => ({
                       ...prev,
-                      AnalyticsProvider: e.target.value as 'umami' | 'google' | 'custom',
+                      AnalyticsProvider: e.target.value as 'umami' | 'google' | 'clarity' | 'custom',
                     }))
                   }
                   className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200'
                 >
                   <option value='umami'>Umami（开源，自托管）</option>
                   <option value='google'>Google Analytics</option>
+                  <option value='clarity'>Microsoft Clarity（免费，热力图+会话回放）</option>
                   <option value='custom'>自定义代码</option>
                 </select>
               </div>
@@ -11672,6 +11673,29 @@ const SiteConfigComponent = ({
                   />
                   <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
                     Google Analytics 4 的 Measurement ID，在 GA 后台「数据流」中获取
+                  </p>
+                </div>
+              )}
+
+              {siteSettings.AnalyticsProvider === 'clarity' && (
+                <div>
+                  <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>
+                    Project ID
+                  </label>
+                  <input
+                    type='text'
+                    value={siteSettings.AnalyticsWebsiteId}
+                    onChange={(e) =>
+                      setSiteSettings((prev) => ({
+                        ...prev,
+                        AnalyticsWebsiteId: e.target.value,
+                      }))
+                    }
+                    placeholder='e.g. abc1234567'
+                    className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200'
+                  />
+                  <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
+                    Microsoft Clarity 的 Project ID，在 clarity.microsoft.com 项目设置中获取
                   </p>
                 </div>
               )}

--- a/src/app/api/admin/site/route.ts
+++ b/src/app/api/admin/site/route.ts
@@ -83,6 +83,11 @@ export async function POST(request: NextRequest) {
       OIDCClientSecret,
       OIDCButtonText,
       OIDCMinTrustLevel,
+      AnalyticsEnabled,
+      AnalyticsProvider,
+      AnalyticsScriptUrl,
+      AnalyticsWebsiteId,
+      AnalyticsCustomScript,
     } = body as {
       SiteName: string;
       Announcement: string;
@@ -138,6 +143,11 @@ export async function POST(request: NextRequest) {
       OIDCClientSecret?: string;
       OIDCButtonText?: string;
       OIDCMinTrustLevel?: number;
+      AnalyticsEnabled?: boolean;
+      AnalyticsProvider?: 'umami' | 'google' | 'custom';
+      AnalyticsScriptUrl?: string;
+      AnalyticsWebsiteId?: string;
+      AnalyticsCustomScript?: string;
     };
 
     // 参数校验
@@ -224,7 +234,15 @@ export async function POST(request: NextRequest) {
       (OIDCClientSecret !== undefined &&
         typeof OIDCClientSecret !== 'string') ||
       (OIDCButtonText !== undefined && typeof OIDCButtonText !== 'string') ||
-      (OIDCMinTrustLevel !== undefined && typeof OIDCMinTrustLevel !== 'number')
+      (OIDCMinTrustLevel !== undefined && typeof OIDCMinTrustLevel !== 'number') ||
+      (AnalyticsEnabled !== undefined && typeof AnalyticsEnabled !== 'boolean') ||
+      (AnalyticsProvider !== undefined &&
+        AnalyticsProvider !== 'umami' &&
+        AnalyticsProvider !== 'google' &&
+        AnalyticsProvider !== 'custom') ||
+      (AnalyticsScriptUrl !== undefined && typeof AnalyticsScriptUrl !== 'string') ||
+      (AnalyticsWebsiteId !== undefined && typeof AnalyticsWebsiteId !== 'string') ||
+      (AnalyticsCustomScript !== undefined && typeof AnalyticsCustomScript !== 'string')
     ) {
       return NextResponse.json({ error: '参数格式错误' }, { status: 400 });
     }
@@ -295,6 +313,11 @@ export async function POST(request: NextRequest) {
       OIDCClientSecret,
       OIDCButtonText,
       OIDCMinTrustLevel,
+      AnalyticsEnabled,
+      AnalyticsProvider,
+      AnalyticsScriptUrl,
+      AnalyticsWebsiteId,
+      AnalyticsCustomScript,
     };
 
     // 写入数据库

--- a/src/app/api/admin/site/route.ts
+++ b/src/app/api/admin/site/route.ts
@@ -144,7 +144,7 @@ export async function POST(request: NextRequest) {
       OIDCButtonText?: string;
       OIDCMinTrustLevel?: number;
       AnalyticsEnabled?: boolean;
-      AnalyticsProvider?: 'umami' | 'google' | 'custom';
+      AnalyticsProvider?: 'umami' | 'google' | 'clarity' | 'custom';
       AnalyticsScriptUrl?: string;
       AnalyticsWebsiteId?: string;
       AnalyticsCustomScript?: string;
@@ -239,6 +239,7 @@ export async function POST(request: NextRequest) {
       (AnalyticsProvider !== undefined &&
         AnalyticsProvider !== 'umami' &&
         AnalyticsProvider !== 'google' &&
+        AnalyticsProvider !== 'clarity' &&
         AnalyticsProvider !== 'custom') ||
       (AnalyticsScriptUrl !== undefined && typeof AnalyticsScriptUrl !== 'string') ||
       (AnalyticsWebsiteId !== undefined && typeof AnalyticsWebsiteId !== 'string') ||

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -115,6 +115,11 @@ export default async function RootLayout({
   let liveEnabled = true;
   let webLiveEnabled = false;
   let customAdFilterVersion = 0;
+  let analyticsEnabled = false;
+  let analyticsProvider: 'umami' | 'google' | 'custom' = 'umami';
+  let analyticsScriptUrl = '';
+  let analyticsWebsiteId = '';
+  let analyticsCustomScript = '';
   let musicFeatureEnabled = false;
   let suwayomiEnabled = false;
   let booksEnabled =
@@ -202,6 +207,12 @@ export default async function RootLayout({
     webLiveEnabled = config.WebLiveEnabled ?? false;
     // 自定义去广告代码版本号
     customAdFilterVersion = config.SiteConfig?.CustomAdFilterVersion || 0;
+    // 流量统计配置
+    analyticsEnabled = config.SiteConfig?.AnalyticsEnabled || false;
+    analyticsProvider = config.SiteConfig?.AnalyticsProvider || 'umami';
+    analyticsScriptUrl = config.SiteConfig?.AnalyticsScriptUrl || '';
+    analyticsWebsiteId = config.SiteConfig?.AnalyticsWebsiteId || '';
+    analyticsCustomScript = config.SiteConfig?.AnalyticsCustomScript || '';
     // 音乐功能配置
     musicFeatureEnabled = config.MusicConfig?.Enabled || false;
     musicProxyEnabled = config.MusicConfig?.ProxyEnabled ?? true;
@@ -335,6 +346,37 @@ export default async function RootLayout({
             __html: `window.RUNTIME_CONFIG = ${JSON.stringify(runtimeConfig)};`,
           }}
         />
+        {/* 流量统计脚本 */}
+        {analyticsEnabled && analyticsProvider === 'umami' && analyticsScriptUrl && (
+          <>
+            {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+            <script
+              async
+              defer
+              data-website-id={analyticsWebsiteId}
+              src={analyticsScriptUrl}
+            />
+          </>
+        )}
+        {analyticsEnabled && analyticsProvider === 'google' && analyticsWebsiteId && (
+          <>
+            {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+            <script
+              async
+              src={`https://www.googletagmanager.com/gtag/js?id=${analyticsWebsiteId}`}
+            />
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', '${analyticsWebsiteId}');`,
+              }}
+            />
+          </>
+        )}
+        {analyticsEnabled && analyticsProvider === 'custom' && analyticsCustomScript && (
+          <script
+            dangerouslySetInnerHTML={{ __html: analyticsCustomScript }}
+          />
+        )}
       </head>
       <body
         className={`${inter.className} min-h-screen bg-white text-gray-900 dark:bg-black dark:text-gray-200`}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -116,7 +116,7 @@ export default async function RootLayout({
   let webLiveEnabled = false;
   let customAdFilterVersion = 0;
   let analyticsEnabled = false;
-  let analyticsProvider: 'umami' | 'google' | 'custom' = 'umami';
+  let analyticsProvider: 'umami' | 'google' | 'clarity' | 'custom' = 'umami';
   let analyticsScriptUrl = '';
   let analyticsWebsiteId = '';
   let analyticsCustomScript = '';
@@ -371,6 +371,13 @@ export default async function RootLayout({
               }}
             />
           </>
+        )}
+        {analyticsEnabled && analyticsProvider === 'clarity' && analyticsWebsiteId && (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window,document,"clarity","script","${analyticsWebsiteId}");`,
+            }}
+          />
         )}
         {analyticsEnabled && analyticsProvider === 'custom' && analyticsCustomScript && (
           <script

--- a/src/lib/admin.types.ts
+++ b/src/lib/admin.types.ts
@@ -73,6 +73,12 @@ export interface AdminConfig {
     OIDCClientSecret?: string; // OIDC Client Secret
     OIDCButtonText?: string; // OIDC登录按钮文字
     OIDCMinTrustLevel?: number; // 最低信任等级（仅LinuxDo网站有效，为0时不判断）
+    // 流量统计配置
+    AnalyticsEnabled?: boolean; // 是否启用流量统计
+    AnalyticsProvider?: 'umami' | 'google' | 'custom'; // 统计服务提供商
+    AnalyticsScriptUrl?: string; // 脚本URL（Umami: umami.js地址; GA: gtag URL; 自定义: 脚本src）
+    AnalyticsWebsiteId?: string; // 网站ID（Umami: website_id; GA: Measurement ID如G-XXXX; 自定义: 留空）
+    AnalyticsCustomScript?: string; // 自定义统计代码（仅custom模式使用，完整的HTML脚本内容）
   };
   UserConfig: {
     Users: {

--- a/src/lib/admin.types.ts
+++ b/src/lib/admin.types.ts
@@ -75,7 +75,7 @@ export interface AdminConfig {
     OIDCMinTrustLevel?: number; // 最低信任等级（仅LinuxDo网站有效，为0时不判断）
     // 流量统计配置
     AnalyticsEnabled?: boolean; // 是否启用流量统计
-    AnalyticsProvider?: 'umami' | 'google' | 'custom'; // 统计服务提供商
+    AnalyticsProvider?: 'umami' | 'google' | 'clarity' | 'custom'; // 统计服务提供商
     AnalyticsScriptUrl?: string; // 脚本URL（Umami: umami.js地址; GA: gtag URL; 自定义: 脚本src）
     AnalyticsWebsiteId?: string; // 网站ID（Umami: website_id; GA: Measurement ID如G-XXXX; 自定义: 留空）
     AnalyticsCustomScript?: string; // 自定义统计代码（仅custom模式使用，完整的HTML脚本内容）

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -328,6 +328,12 @@ async function getInitConfig(
       TurnstileSiteKey: '',
       TurnstileSecretKey: '',
       DefaultUserTags: [],
+      // 流量统计配置
+      AnalyticsEnabled: false,
+      AnalyticsProvider: 'umami',
+      AnalyticsScriptUrl: '',
+      AnalyticsWebsiteId: '',
+      AnalyticsCustomScript: '',
     },
     UserConfig: {
       Users: [],
@@ -587,6 +593,22 @@ export function configSelfCheck(adminConfig: AdminConfig): AdminConfig {
   }
   if (adminConfig.SiteConfig.DefaultUserTags === undefined) {
     adminConfig.SiteConfig.DefaultUserTags = [];
+  }
+  // 流量统计配置补全
+  if (adminConfig.SiteConfig.AnalyticsEnabled === undefined) {
+    adminConfig.SiteConfig.AnalyticsEnabled = false;
+  }
+  if (adminConfig.SiteConfig.AnalyticsProvider === undefined) {
+    adminConfig.SiteConfig.AnalyticsProvider = 'umami';
+  }
+  if (adminConfig.SiteConfig.AnalyticsScriptUrl === undefined) {
+    adminConfig.SiteConfig.AnalyticsScriptUrl = '';
+  }
+  if (adminConfig.SiteConfig.AnalyticsWebsiteId === undefined) {
+    adminConfig.SiteConfig.AnalyticsWebsiteId = '';
+  }
+  if (adminConfig.SiteConfig.AnalyticsCustomScript === undefined) {
+    adminConfig.SiteConfig.AnalyticsCustomScript = '';
   }
   if (!adminConfig.TelegramConfig) {
     adminConfig.TelegramConfig = {


### PR DESCRIPTION
## Summary

Adds traffic analytics support to the admin panel, allowing site owners to integrate third-party analytics services without modifying code.

## Supported Providers

| Provider | Config Fields | Features |
|----------|--------------|----------|
| **Umami** | Script URL + Website ID | Open-source, self-hosted, privacy-friendly |
| **Google Analytics** | Measurement ID (G-XXXX) | Industry standard, comprehensive metrics |
| **Microsoft Clarity** | Project ID | Free, heatmaps, session recordings |
| **Custom** | Full script code | Any third-party (百度统计, 51la, Plausible, etc.) |

## Changes

### New fields in `SiteConfig`
- `AnalyticsEnabled` (boolean) — master toggle
- `AnalyticsProvider` (`umami` | `google` | `clarity` | `custom`) — provider selector
- `AnalyticsScriptUrl` (string) — script URL for Umami
- `AnalyticsWebsiteId` (string) — Website ID / Measurement ID / Project ID
- `AnalyticsCustomScript` (string) — full script code for custom provider

### Files modified

| File | Changes |
|------|---------|
| `src/lib/admin.types.ts` | Add 5 analytics fields to `SiteConfig` interface |
| `src/lib/config.ts` | Default values in `getInitConfig()` + `configSelfCheck()` |
| `src/app/api/admin/site/route.ts` | Destructuring, type validation, and save logic |
| `src/app/admin/page.tsx` | `SiteConfig` type, state init, config sync, UI component with provider-specific inputs |
| `src/app/layout.tsx` | Inject analytics scripts into `<head>` based on provider |

## How it works

1. Admin enables analytics in **Site Config > Traffic Analytics** panel
2. Selects a provider and fills in the required fields
3. On save, the config is stored in the database
4. `layout.tsx` reads the config server-side and injects the appropriate script into `<head>`:
   - **Umami**: `<script async defer data-website-id="..." src="..." />`
   - **Google Analytics**: gtag.js + config script
   - **Microsoft Clarity**: Clarity tracking snippet with Project ID
   - **Custom**: `dangerouslySetInnerHTML` with user-provided script

## Screenshots

The analytics config UI appears as a collapsible panel at the bottom of Site Config, with:
- Enable/disable toggle
- Provider dropdown (4 options)
- Provider-specific input fields (shown/hidden based on selection)
- Helpful placeholder text and descriptions for each field

## Verification

- ✅ TypeScript type check passes (`tsc --noEmit`)
- ✅ Successfully deployed and tested on EdgeOne Pages
- ✅ All 4 providers verified (Umami, GA, Clarity, Custom script injection)
- ✅ Backward compatible (analytics disabled by default, `configSelfCheck` fills defaults for existing configs)

## Compatibility

- No breaking changes — all new fields are optional with sensible defaults
- Existing configs without analytics fields will be auto-filled by `configSelfCheck()`
- Works with all storage backends (Redis, D1, Turso, PostgreSQL)