### PR TITLE
feat(player): 鸿蒙端支持原生 HLS 切换与投屏

### DIFF
--- a/src/app/api/proxy-m3u8/route.ts
+++ b/src/app/api/proxy-m3u8/route.ts
@@ -18,6 +18,8 @@ export async function GET(request: NextRequest) {
     const m3u8Url = searchParams.get('url');
     const source = searchParams.get('source') || '';
     const token = searchParams.get('token');
+    const adBlockEnabled = searchParams.get('adblock') !== 'false';
+    const proxySegments = searchParams.get('proxySegments') === 'true';
 
     // Token 鉴权：如果环境变量设置了 token，则必须验证
     const envToken = process.env.NEXT_PUBLIC_PROXY_M3U8_TOKEN;
@@ -144,35 +146,45 @@ export async function GET(request: NextRequest) {
       // 不直接拒绝（可能是不规范但仍可播放的 m3u8），仅打印警告继续处理
     }
 
-    // 执行去广告逻辑
-    const config = await getConfig();
-    const customAdFilterCode = config.SiteConfig?.CustomAdFilterCode || '';
+    // 执行去广告逻辑；原生 HLS 可通过 adblock=false 保留代理但关闭过滤。
+    if (adBlockEnabled) {
+      const config = await getConfig();
+      const customAdFilterCode = config.SiteConfig?.CustomAdFilterCode || '';
 
-    if (customAdFilterCode && customAdFilterCode.trim()) {
-      try {
-        // 移除 TypeScript 类型注解,转换为纯 JavaScript
-        const jsCode = customAdFilterCode
-          .replace(/(\w+)\s*:\s*(string|number|boolean|any|void|never|unknown|object)\s*([,)])/g, '$1$3')
-          .replace(/\)\s*:\s*(string|number|boolean|any|void|never|unknown|object)\s*\{/g, ') {')
-          .replace(/(const|let|var)\s+(\w+)\s*:\s*(string|number|boolean|any|void|never|unknown|object)\s*=/g, '$1 $2 =');
+      if (customAdFilterCode && customAdFilterCode.trim()) {
+        try {
+          // 移除 TypeScript 类型注解,转换为纯 JavaScript
+          const jsCode = customAdFilterCode
+            .replace(/(\w+)\s*:\s*(string|number|boolean|any|void|never|unknown|object)\s*([,)])/g, '$1$3')
+            .replace(/\)\s*:\s*(string|number|boolean|any|void|never|unknown|object)\s*\{/g, ') {')
+            .replace(/(const|let|var)\s+(\w+)\s*:\s*(string|number|boolean|any|void|never|unknown|object)\s*=/g, '$1 $2 =');
 
-        // 创建并执行自定义函数
-        const customFunction = new Function('type', 'm3u8Content',
-          jsCode + '\nreturn filterAdsFromM3U8(type, m3u8Content);'
-        );
-        m3u8Content = customFunction(source, m3u8Content);
-      } catch (err) {
-        console.error('执行自定义去广告代码失败,使用默认规则:', err);
-        // 继续使用默认规则
+          // 创建并执行自定义函数
+          const customFunction = new Function('type', 'm3u8Content',
+            jsCode + '\nreturn filterAdsFromM3U8(type, m3u8Content);'
+          );
+          m3u8Content = customFunction(source, m3u8Content);
+        } catch (err) {
+          console.error('执行自定义去广告代码失败,使用默认规则:', err);
+          // 继续使用默认规则
+          m3u8Content = filterAdsFromM3U8Default(source, m3u8Content);
+        }
+      } else {
+        // 使用默认去广告规则
         m3u8Content = filterAdsFromM3U8Default(source, m3u8Content);
       }
-    } else {
-      // 使用默认去广告规则
-      m3u8Content = filterAdsFromM3U8Default(source, m3u8Content);
     }
 
     // 处理 m3u8 中的相对链接
-    m3u8Content = resolveM3u8Links(m3u8Content, m3u8Url, source, origin, token || '');
+    m3u8Content = resolveM3u8Links(
+      m3u8Content,
+      m3u8Url,
+      source,
+      origin,
+      token || '',
+      adBlockEnabled,
+      proxySegments
+    );
 
     // 返回处理后的 m3u8 内容
     return new NextResponse(m3u8Content, {
@@ -254,9 +266,17 @@ function filterAdsFromM3U8Default(type: string, m3u8Content: string): string {
  * 将 m3u8 中的相对链接转换为绝对链接，并将子 m3u8 链接转为代理链接。
  * 此函数仅在代理模式下由服务端调用。
  * - 子 m3u8 链接 → 指向 /api/proxy-m3u8（递归代理）
- * - ts 分片/密钥 → directplay 模式指向 /api/proxy/vod/segment（解决 CORS）
+ * - ts 分片/密钥 → directplay 或 proxySegments 模式指向 /api/proxy/vod/segment
  */
-function resolveM3u8Links(m3u8Content: string, baseUrl: string, source: string, proxyOrigin: string, token: string): string {
+function resolveM3u8Links(
+  m3u8Content: string,
+  baseUrl: string,
+  source: string,
+  proxyOrigin: string,
+  token: string,
+  adBlockEnabled: boolean,
+  proxySegments: boolean
+): string {
   const lines = m3u8Content.split('\n');
   const resolvedLines = [];
 
@@ -285,9 +305,9 @@ function resolveM3u8Links(m3u8Content: string, baseUrl: string, source: string, 
           }
         }
 
-        // 直链播放模式：通过代理访问密钥，避免 CORS 问题
-        if (source === 'directplay') {
-          keyUri = `${proxyOrigin}/api/proxy/vod/segment?url=${encodeURIComponent(keyUri)}&source=directplay`;
+        // 直链/全量代理模式：通过代理访问密钥，避免 CORS 问题
+        if (source === 'directplay' || proxySegments) {
+          keyUri = `${proxyOrigin}/api/proxy/vod/segment?url=${encodeURIComponent(keyUri)}&source=${encodeURIComponent(source)}`;
         }
 
         // 替换原来的 URI
@@ -331,10 +351,12 @@ function resolveM3u8Links(m3u8Content: string, baseUrl: string, source: string, 
     const isM3u8 = url.includes('.m3u8') || isNextLineUrl;
     if (isM3u8) {
       const tokenParam = token ? `&token=${encodeURIComponent(token)}` : '';
-      url = `${proxyOrigin}/api/proxy-m3u8?url=${encodeURIComponent(url)}${source ? `&source=${encodeURIComponent(source)}` : ''}${tokenParam}`;
-    } else if (source === 'directplay') {
-      // 直链播放模式：通过代理访问媒体分片（ts/jpeg/png 等），避免 CORS 问题
-      url = `${proxyOrigin}/api/proxy/vod/segment?url=${encodeURIComponent(url)}&source=directplay`;
+      const adBlockParam = adBlockEnabled ? '' : '&adblock=false';
+      const proxySegmentsParam = proxySegments ? '&proxySegments=true' : '';
+      url = `${proxyOrigin}/api/proxy-m3u8?url=${encodeURIComponent(url)}${source ? `&source=${encodeURIComponent(source)}` : ''}${tokenParam}${adBlockParam}${proxySegmentsParam}`;
+    } else if (source === 'directplay' || proxySegments) {
+      // 直链/全量代理模式：通过代理访问媒体分片（ts/jpeg/png 等）
+      url = `${proxyOrigin}/api/proxy/vod/segment?url=${encodeURIComponent(url)}&source=${encodeURIComponent(source)}`;
     }
 
     resolvedLines.push(url);

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -9976,43 +9976,13 @@ function PlayPageClient() {
         </div>
         {/* 第二行：播放器和选集 */}
         <div className='space-y-2'>
-          <div className='flex items-center justify-end gap-2'>
-            {isHarmonyOS && isHlsPlaybackUrl(videoUrl) && (
-              <div
-                className='inline-flex items-center rounded-full border border-gray-200/60 bg-white/80 p-0.5 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/80'
-                role='group'
-                aria-label='鸿蒙 HLS 播放器切换'
-              >
-                <span className='px-2 text-xs font-medium text-gray-500 dark:text-gray-400'>
-                  播放器
-                </span>
-                {([
-                  ['hlsjs', 'HLS.js'],
-                  ['native', '原生 HLS'],
-                ] as const).map(([mode, label]) => (
-                  <button
-                    key={mode}
-                    type='button'
-                    onClick={() => switchHarmonyHlsPlaybackMode(mode)}
-                    aria-pressed={harmonyHlsPlaybackMode === mode}
-                    className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
-                      harmonyHlsPlaybackMode === mode
-                        ? 'bg-green-500 text-white shadow-sm'
-                        : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
-                    }`}
-                  >
-                    {label}
-                  </button>
-                ))}
-              </div>
-            )}
-
-            {/* 折叠控制 - 仅在 lg 及以上屏幕显示 */}
+          {/* 折叠控制 - 仅在 lg 及以上屏幕显示 */}
+          <div className='hidden lg:flex justify-end'>
             <button
               onClick={() =>
                 setIsEpisodeSelectorCollapsed(!isEpisodeSelectorCollapsed)
               }
-              className='group relative hidden lg:flex items-center space-x-1.5 px-3 py-1.5 rounded-full bg-white/80 hover:bg-white dark:bg-gray-800/80 dark:hover:bg-gray-800 backdrop-blur-sm border border-gray-200/50 dark:border-gray-700/50 shadow-sm hover:shadow-md transition-all duration-200'
+              className='group relative flex items-center space-x-1.5 px-3 py-1.5 rounded-full bg-white/80 hover:bg-white dark:bg-gray-800/80 dark:hover:bg-gray-800 backdrop-blur-sm border border-gray-200/50 dark:border-gray-700/50 shadow-sm hover:shadow-md transition-all duration-200'
               title={
                 isEpisodeSelectorCollapsed ? '显示选集面板' : '隐藏选集面板'
               }
@@ -10598,6 +10568,54 @@ function PlayPageClient() {
                           {externalPlayerAdBlock ? '去广告' : '去广告'}
                         </span>
                       </button>
+
+                      {/* 鸿蒙 HLS.js 开关：关闭后使用原生 HLS，便于浏览器投屏 */}
+                      {isHarmonyOS && isHlsPlaybackUrl(videoUrl) && (
+                        <button
+                          type='button'
+                          onClick={() =>
+                            switchHarmonyHlsPlaybackMode(
+                              harmonyHlsPlaybackMode === 'hlsjs'
+                                ? 'native'
+                                : 'hlsjs'
+                            )
+                          }
+                          aria-pressed={harmonyHlsPlaybackMode === 'hlsjs'}
+                          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all duration-200 shadow-sm hover:shadow-md cursor-pointer border flex-shrink-0 ${harmonyHlsPlaybackMode === 'hlsjs'
+                            ? 'bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white border-blue-400'
+                            : 'bg-white hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600'
+                            }`}
+                          title={
+                            harmonyHlsPlaybackMode === 'hlsjs'
+                              ? 'HLS.js 已开启，点击切换为原生 HLS'
+                              : 'HLS.js 已关闭，当前使用原生 HLS'
+                          }
+                        >
+                          <svg
+                            className='w-4 h-4 flex-shrink-0'
+                            fill='none'
+                            stroke='currentColor'
+                            viewBox='0 0 24 24'
+                          >
+                            {harmonyHlsPlaybackMode === 'hlsjs' ? (
+                              <path
+                                strokeLinecap='round'
+                                strokeLinejoin='round'
+                                strokeWidth='2'
+                                d='M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z'
+                              />
+                            ) : (
+                              <path
+                                strokeLinecap='round'
+                                strokeLinejoin='round'
+                                strokeWidth='2'
+                                d='M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636'
+                              />
+                            )}
+                          </svg>
+                          <span className='whitespace-nowrap'>HLS.js</span>
+                        </button>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -414,7 +414,7 @@ function PlayPageClient() {
     blockAdEnabledRef.current = blockAdEnabled;
   }, [blockAdEnabled]);
 
-  // 外部播放器去广告开关（独立状态，默认 false）
+  // 工具栏去广告开关：用于外部播放器及鸿蒙原生 HLS，默认 false
   const [externalPlayerAdBlock, setExternalPlayerAdBlock] = useState<boolean>(() => {
     if (typeof window !== 'undefined') {
       const v = localStorage.getItem('external_player_adblock');
@@ -1610,6 +1610,10 @@ function PlayPageClient() {
         return 'hlsjs';
       }
     });
+  const nativeHlsAdBlockEnabled =
+    isHarmonyOS &&
+    harmonyHlsPlaybackMode === 'native' &&
+    externalPlayerAdBlock;
 
   // 视频清晰度列表
   const [videoQualities, setVideoQualities] = useState<Array<{ name: string, url: string }>>([]);
@@ -2020,6 +2024,7 @@ function PlayPageClient() {
   const artRef = useRef<HTMLDivElement | null>(null);
   const activeHarmonyHlsPlaybackModeRef =
     useRef<HarmonyHlsPlaybackMode | null>(null);
+  const activeNativeHlsAdBlockRef = useRef<boolean | null>(null);
   const syncAnime4KCanvasFlip = (flip?: string) => {
     const canvas = anime4kRef.current?.canvas as HTMLCanvasElement | undefined;
     if (!canvas) return;
@@ -3903,9 +3908,7 @@ function PlayPageClient() {
     applyVideoCrossOrigin(video, currentSourceRef.current);
   };
 
-  const switchHarmonyHlsPlaybackMode = (mode: HarmonyHlsPlaybackMode) => {
-    if (mode === harmonyHlsPlaybackMode) return;
-
+  const prepareHarmonyHlsReinit = () => {
     const player = artPlayerRef.current;
     if (player) {
       const currentTime = Number(player.currentTime) || 0;
@@ -3913,17 +3916,82 @@ function PlayPageClient() {
       resumePlayingAfterHlsModeSwitchRef.current = !player.paused;
     }
 
-    try {
-      localStorage.setItem(HARMONY_HLS_PLAYBACK_MODE_KEY, mode);
-    } catch {
-      // 隐私模式等场景可能禁用 localStorage，但不应阻止本次切换。
-    }
     setVideoError(null);
     setCorsFailedUrl(null);
     setVideoLoadingStage('sourceChanging');
     setIsVideoLoading(true);
     setPlayerReady(false);
+  };
+
+  const buildNativeHlsPlaybackUrl = (url: string) => {
+    if (!url || typeof window === 'undefined') return url;
+
+    try {
+      const isAbsoluteUrl = /^https?:\/\//i.test(url);
+      const parsedUrl = new URL(url, window.location.origin);
+
+      // 已经走服务端去广告代理时，只切换过滤参数，避免重复嵌套代理。
+      if (parsedUrl.pathname === '/api/proxy-m3u8') {
+        if (nativeHlsAdBlockEnabled) {
+          parsedUrl.searchParams.delete('adblock');
+        } else {
+          parsedUrl.searchParams.set('adblock', 'false');
+        }
+        return isAbsoluteUrl
+          ? parsedUrl.toString()
+          : `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
+      }
+
+      if (!nativeHlsAdBlockEnabled) return url;
+
+      let originalUrl = url;
+      let proxySegments = false;
+
+      // 保留视频源原有的全量代理能力，同时改由 proxy-m3u8 执行去广告。
+      if (parsedUrl.pathname === '/api/proxy/vod/m3u8') {
+        originalUrl = parsedUrl.searchParams.get('url') || '';
+        proxySegments = true;
+      } else if (parsedUrl.pathname === '/api/proxy/m3u8') {
+        originalUrl = parsedUrl.searchParams.get('url') || '';
+      }
+
+      if (!/^https?:\/\//i.test(originalUrl)) return url;
+
+      const params = new URLSearchParams({
+        url: originalUrl,
+        source: currentSourceRef.current,
+      });
+      if (proxyToken) params.set('token', proxyToken);
+      if (proxySegments) params.set('proxySegments', 'true');
+      return `/api/proxy-m3u8?${params.toString()}`;
+    } catch (error) {
+      console.warn('[Harmony HLS] 构建原生去广告地址失败:', error);
+      return url;
+    }
+  };
+
+  const switchHarmonyHlsPlaybackMode = (mode: HarmonyHlsPlaybackMode) => {
+    if (mode === harmonyHlsPlaybackMode) return;
+
+    prepareHarmonyHlsReinit();
+
+    try {
+      localStorage.setItem(HARMONY_HLS_PLAYBACK_MODE_KEY, mode);
+    } catch {
+      // 隐私模式等场景可能禁用 localStorage，但不应阻止本次切换。
+    }
     setHarmonyHlsPlaybackMode(mode);
+  };
+
+  const toggleToolbarAdBlock = () => {
+    if (
+      isHarmonyOS &&
+      harmonyHlsPlaybackMode === 'native' &&
+      isHlsPlaybackUrl(videoUrl)
+    ) {
+      prepareHarmonyHlsReinit();
+    }
+    setExternalPlayerAdBlock(!externalPlayerAdBlock);
   };
 
   // Wake Lock 相关函数
@@ -6809,7 +6877,9 @@ function PlayPageClient() {
 
     const needsHarmonyHlsModeReinit =
       isHarmonyOS &&
-      activeHarmonyHlsPlaybackModeRef.current !== harmonyHlsPlaybackMode;
+      (activeHarmonyHlsPlaybackModeRef.current !== harmonyHlsPlaybackMode ||
+        (harmonyHlsPlaybackMode === 'native' &&
+          activeNativeHlsAdBlockRef.current !== nativeHlsAdBlockEnabled));
 
     // 非WebKit浏览器且播放器已存在，使用switch方法切换
     if (!isWebkit && artPlayerRef.current && !needsHarmonyHlsModeReinit) {
@@ -6831,9 +6901,13 @@ function PlayPageClient() {
       artPlayerRef.current.title = `${videoTitle} - ${playerEpisodeLabel}`;
       artPlayerRef.current.poster = videoCover;
       if (artPlayerRef.current?.video) {
+        const exposedVideoUrl =
+          isHarmonyOS && harmonyHlsPlaybackMode === 'native'
+            ? buildNativeHlsPlaybackUrl(videoUrl)
+            : videoUrl;
         ensureVideoSource(
           artPlayerRef.current.video as HTMLVideoElement,
-          videoUrl
+          exposedVideoUrl
         );
       }
       return;
@@ -7083,8 +7157,9 @@ function PlayPageClient() {
 
                 // 不 attach MediaSource，直接把 m3u8 交给 ArkWeb/浏览器原生播放器。
                 // currentSrc 会保留实际播放地址，供浏览器内置投屏功能读取。
-                video.src = url;
-                ensureVideoSource(video, url);
+                const nativePlaybackUrl = buildNativeHlsPlaybackUrl(url);
+                video.src = nativePlaybackUrl;
+                ensureVideoSource(video, nativePlaybackUrl);
                 video.load();
                 return;
               }
@@ -9550,11 +9625,16 @@ function PlayPageClient() {
         activeHarmonyHlsPlaybackModeRef.current = isHarmonyOS
           ? harmonyHlsPlaybackMode
           : 'hlsjs';
+        activeNativeHlsAdBlockRef.current = nativeHlsAdBlockEnabled;
 
         if (artPlayerRef.current?.video) {
+          const exposedVideoUrl =
+            isHarmonyOS && harmonyHlsPlaybackMode === 'native'
+              ? buildNativeHlsPlaybackUrl(videoUrl)
+              : videoUrl;
           ensureVideoSource(
             artPlayerRef.current.video as HTMLVideoElement,
-            videoUrl
+            exposedVideoUrl
           );
         }
       } catch (err) {
@@ -9565,7 +9645,13 @@ function PlayPageClient() {
 
     // 调用异步初始化函数
     initPlayer();
-  }, [videoUrl, loading, blockAdEnabled, harmonyHlsPlaybackMode]);
+  }, [
+    videoUrl,
+    loading,
+    blockAdEnabled,
+    harmonyHlsPlaybackMode,
+    nativeHlsAdBlockEnabled,
+  ]);
 
   // 当组件卸载时清理定时器、Wake Lock 和播放器资源
   useEffect(() => {
@@ -10535,7 +10621,7 @@ function PlayPageClient() {
 
                       {/* 去广告开关 */}
                       <button
-                        onClick={() => setExternalPlayerAdBlock(!externalPlayerAdBlock)}
+                        onClick={toggleToolbarAdBlock}
                         className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all duration-200 shadow-sm hover:shadow-md cursor-pointer border flex-shrink-0 ${externalPlayerAdBlock
                           ? 'bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white border-blue-400'
                           : 'bg-white hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600'

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -126,6 +126,7 @@ interface SearchCachePayload {
 
 type CustomSubtitleEngine = 'native' | 'jassub';
 type PlaybackSourceBadge = 'local' | 'offline' | null;
+type HarmonyHlsPlaybackMode = 'hlsjs' | 'native';
 
 interface CustomSubtitleState {
   name: string;
@@ -155,10 +156,17 @@ interface JassubSubtitleInstance {
 }
 
 const PLAYBACK_RATE_OPTIONS = [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
+const HARMONY_HLS_PLAYBACK_MODE_KEY = 'harmony_hls_playback_mode';
 const JASSUB_ASSET_BASE = '/assets/jassub';
 const JASSUB_CJK_FONT_FAMILY = 'noto sans cjk sc';
 const JASSUB_CJK_FONT_URL = `${JASSUB_ASSET_BASE}/NotoSansCJK-Regular.ttc`;
 const ADVANCED_SUBTITLE_FORMATS = new Set(['ass', 'ssa']);
+
+const isHlsPlaybackUrl = (url: string) =>
+  /\.m3u8?(?:$|[/?#])/i.test(url) ||
+  url.includes('/api/proxy-m3u8') ||
+  url.includes('/api/proxy/vod/m3u8');
+
 const PLAY_SHORTCUT_GROUPS = [
   {
     title: '播放控制',
@@ -1580,6 +1588,29 @@ function PlayPageClient() {
   const [videoUrl, setVideoUrl] = useState('');
   const [playbackSourceBadge, setPlaybackSourceBadge] = useState<PlaybackSourceBadge>(null);
 
+  // 鸿蒙浏览器使用原生 HLS 时，video.currentSrc 会保留真实 m3u8，便于浏览器投屏。
+  const [isHarmonyOS] = useState(
+    () =>
+      typeof navigator !== 'undefined' &&
+      /OpenHarmony/i.test(navigator.userAgent)
+  );
+  const [harmonyHlsPlaybackMode, setHarmonyHlsPlaybackMode] =
+    useState<HarmonyHlsPlaybackMode>(() => {
+      if (
+        typeof navigator === 'undefined' ||
+        !/OpenHarmony/i.test(navigator.userAgent)
+      ) {
+        return 'hlsjs';
+      }
+
+      try {
+        const savedMode = localStorage.getItem(HARMONY_HLS_PLAYBACK_MODE_KEY);
+        return savedMode === 'native' ? 'native' : 'hlsjs';
+      } catch {
+        return 'hlsjs';
+      }
+    });
+
   // 视频清晰度列表
   const [videoQualities, setVideoQualities] = useState<Array<{ name: string, url: string }>>([]);
 
@@ -1816,6 +1847,8 @@ function PlayPageClient() {
 
   // 用于记录是否需要在播放器 ready 后跳转到指定进度
   const resumeTimeRef = useRef<number | null>(null);
+  // 切换鸿蒙 HLS 内核时，同时恢复切换前的播放/暂停状态。
+  const resumePlayingAfterHlsModeSwitchRef = useRef<boolean | null>(null);
   // 播放记录跳转按钮状态
   const playRecordJumpDismissedRef = useRef(false); // 记录用户是否已经关闭过跳转按钮
   const playRecordJumpLayerRef = useRef<any>(null); // 保存跳转按钮层的引用
@@ -1985,6 +2018,8 @@ function PlayPageClient() {
 
   const artPlayerRef = useRef<any>(null);
   const artRef = useRef<HTMLDivElement | null>(null);
+  const activeHarmonyHlsPlaybackModeRef =
+    useRef<HarmonyHlsPlaybackMode | null>(null);
   const syncAnime4KCanvasFlip = (flip?: string) => {
     const canvas = anime4kRef.current?.canvas as HTMLCanvasElement | undefined;
     if (!canvas) return;
@@ -3866,6 +3901,29 @@ function PlayPageClient() {
 
     // openlist/emby/xiaoya/netdisk：CORS 模式加载，需配套「moontvplus 扩展」注入 ACAO 后 Anime4K 才能读帧
     applyVideoCrossOrigin(video, currentSourceRef.current);
+  };
+
+  const switchHarmonyHlsPlaybackMode = (mode: HarmonyHlsPlaybackMode) => {
+    if (mode === harmonyHlsPlaybackMode) return;
+
+    const player = artPlayerRef.current;
+    if (player) {
+      const currentTime = Number(player.currentTime) || 0;
+      resumeTimeRef.current = currentTime > 0 ? currentTime : null;
+      resumePlayingAfterHlsModeSwitchRef.current = !player.paused;
+    }
+
+    try {
+      localStorage.setItem(HARMONY_HLS_PLAYBACK_MODE_KEY, mode);
+    } catch {
+      // 隐私模式等场景可能禁用 localStorage，但不应阻止本次切换。
+    }
+    setVideoError(null);
+    setCorsFailedUrl(null);
+    setVideoLoadingStage('sourceChanging');
+    setIsVideoLoading(true);
+    setPlayerReady(false);
+    setHarmonyHlsPlaybackMode(mode);
   };
 
   // Wake Lock 相关函数
@@ -6749,8 +6807,12 @@ function PlayPageClient() {
       return undefined;
     };
 
+    const needsHarmonyHlsModeReinit =
+      isHarmonyOS &&
+      activeHarmonyHlsPlaybackModeRef.current !== harmonyHlsPlaybackMode;
+
     // 非WebKit浏览器且播放器已存在，使用switch方法切换
-    if (!isWebkit && artPlayerRef.current) {
+    if (!isWebkit && artPlayerRef.current && !needsHarmonyHlsModeReinit) {
       // 显式设置类型，确保代理 URL 能被 HLS.js 正确处理
       const videoType = getVideoType(videoUrl);
       if (videoType) {
@@ -7013,6 +7075,20 @@ function PlayPageClient() {
           // HLS 支持配置
           customType: {
             m3u8: function (video: HTMLVideoElement, url: string) {
+              if (isHarmonyOS && harmonyHlsPlaybackMode === 'native') {
+                if (video.hls) {
+                  video.hls.destroy();
+                  delete video.hls;
+                }
+
+                // 不 attach MediaSource，直接把 m3u8 交给 ArkWeb/浏览器原生播放器。
+                // currentSrc 会保留实际播放地址，供浏览器内置投屏功能读取。
+                video.src = url;
+                ensureVideoSource(video, url);
+                video.load();
+                return;
+              }
+
               if (!Hls) {
                 console.error('HLS.js 未加载');
                 return;
@@ -8984,6 +9060,17 @@ function PlayPageClient() {
           }
           resumeTimeRef.current = null;
 
+          const shouldResumePlaying =
+            resumePlayingAfterHlsModeSwitchRef.current;
+          resumePlayingAfterHlsModeSwitchRef.current = null;
+          if (shouldResumePlaying === false) {
+            artPlayerRef.current.pause();
+          } else if (shouldResumePlaying === true) {
+            Promise.resolve(artPlayerRef.current.play()).catch((error) => {
+              console.warn('[Harmony HLS] 恢复播放失败:', error);
+            });
+          }
+
           schedulePlayerTimeout(() => {
             if (!artPlayerRef.current) {
               return;
@@ -9460,6 +9547,10 @@ function PlayPageClient() {
           }
         });
 
+        activeHarmonyHlsPlaybackModeRef.current = isHarmonyOS
+          ? harmonyHlsPlaybackMode
+          : 'hlsjs';
+
         if (artPlayerRef.current?.video) {
           ensureVideoSource(
             artPlayerRef.current.video as HTMLVideoElement,
@@ -9474,7 +9565,7 @@ function PlayPageClient() {
 
     // 调用异步初始化函数
     initPlayer();
-  }, [videoUrl, loading, blockAdEnabled]);
+  }, [videoUrl, loading, blockAdEnabled, harmonyHlsPlaybackMode]);
 
   // 当组件卸载时清理定时器、Wake Lock 和播放器资源
   useEffect(() => {
@@ -9885,13 +9976,43 @@ function PlayPageClient() {
         </div>
         {/* 第二行：播放器和选集 */}
         <div className='space-y-2'>
-          {/* 折叠控制 - 仅在 lg 及以上屏幕显示 */}
-          <div className='hidden lg:flex justify-end'>
+          <div className='flex items-center justify-end gap-2'>
+            {isHarmonyOS && isHlsPlaybackUrl(videoUrl) && (
+              <div
+                className='inline-flex items-center rounded-full border border-gray-200/60 bg-white/80 p-0.5 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/80'
+                role='group'
+                aria-label='鸿蒙 HLS 播放器切换'
+              >
+                <span className='px-2 text-xs font-medium text-gray-500 dark:text-gray-400'>
+                  播放器
+                </span>
+                {([
+                  ['hlsjs', 'HLS.js'],
+                  ['native', '原生 HLS'],
+                ] as const).map(([mode, label]) => (
+                  <button
+                    key={mode}
+                    type='button'
+                    onClick={() => switchHarmonyHlsPlaybackMode(mode)}
+                    aria-pressed={harmonyHlsPlaybackMode === mode}
+                    className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+                      harmonyHlsPlaybackMode === mode
+                        ? 'bg-green-500 text-white shadow-sm'
+                        : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* 折叠控制 - 仅在 lg 及以上屏幕显示 */}
             <button
               onClick={() =>
                 setIsEpisodeSelectorCollapsed(!isEpisodeSelectorCollapsed)
               }
-              className='group relative flex items-center space-x-1.5 px-3 py-1.5 rounded-full bg-white/80 hover:bg-white dark:bg-gray-800/80 dark:hover:bg-gray-800 backdrop-blur-sm border border-gray-200/50 dark:border-gray-700/50 shadow-sm hover:shadow-md transition-all duration-200'
+              className='group relative hidden lg:flex items-center space-x-1.5 px-3 py-1.5 rounded-full bg-white/80 hover:bg-white dark:bg-gray-800/80 dark:hover:bg-gray-800 backdrop-blur-sm border border-gray-200/50 dark:border-gray-700/50 shadow-sm hover:shadow-md transition-all duration-200'
               title={
                 isEpisodeSelectorCollapsed ? '显示选集面板' : '隐藏选集面板'
               }

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -98,6 +98,7 @@ import { useDownload } from '@/contexts/DownloadContext';
 declare global {
   interface HTMLVideoElement {
     hls?: any;
+    harmonyNativeMetadataHandler?: () => void;
   }
 }
 
@@ -4065,6 +4066,17 @@ function PlayPageClient() {
           artPlayerRef.current.video.hls.destroy();
         }
 
+        const cleanupVideo = artPlayerRef.current.video as
+          | HTMLVideoElement
+          | undefined;
+        if (cleanupVideo?.harmonyNativeMetadataHandler) {
+          cleanupVideo.removeEventListener(
+            'loadedmetadata',
+            cleanupVideo.harmonyNativeMetadataHandler
+          );
+          delete cleanupVideo.harmonyNativeMetadataHandler;
+        }
+
         // 销毁 ArtPlayer 实例
         artPlayerRef.current.destroy();
         artPlayerRef.current = null;
@@ -7095,7 +7107,9 @@ function PlayPageClient() {
           volume: 0.7,
           isLive: false,
           muted: false,
-          autoplay: true,
+          // 原生 HLS 由 loadedmetadata 中的一次性逻辑恢复播放，避免夸克
+          // 超级播放器接管后又被 Artplayer 的延迟 autoplay 覆盖暂停状态。
+          autoplay: !(isHarmonyOS && harmonyHlsPlaybackMode === 'native'),
           pip: true,
           autoSize: false,
           autoMini: false,
@@ -7155,9 +7169,91 @@ function PlayPageClient() {
                   delete video.hls;
                 }
 
+                // 快速换源时移除上一个源尚未触发的恢复监听，避免旧进度
+                // 在新源 loadedmetadata 后被错误写回。
+                if (video.harmonyNativeMetadataHandler) {
+                  video.removeEventListener(
+                    'loadedmetadata',
+                    video.harmonyNativeMetadataHandler
+                  );
+                }
+
+                const nativeResumeTime = resumeTimeRef.current;
+                const shouldResumeNativePlayback =
+                  resumePlayingAfterHlsModeSwitchRef.current ?? true;
+                resumeTimeRef.current = null;
+                resumePlayingAfterHlsModeSwitchRef.current = null;
+
+                const restoreNativePlayback = () => {
+                  if (
+                    video.harmonyNativeMetadataHandler !==
+                    restoreNativePlayback
+                  ) {
+                    return;
+                  }
+                  delete video.harmonyNativeMetadataHandler;
+
+                  if (nativeResumeTime && nativeResumeTime > 0) {
+                    try {
+                      const duration = Number.isFinite(video.duration)
+                        ? video.duration
+                        : 0;
+                      const target =
+                        duration && nativeResumeTime >= duration - 2
+                          ? Math.max(0, duration - 5)
+                          : nativeResumeTime;
+                      video.currentTime = target;
+                      console.log(
+                        '[Harmony HLS] loadedmetadata 恢复播放进度:',
+                        target
+                      );
+                    } catch (error) {
+                      console.warn(
+                        '[Harmony HLS] loadedmetadata 恢复进度失败:',
+                        error
+                      );
+                    }
+                  }
+
+                  if (!shouldResumeNativePlayback) {
+                    video.pause();
+                    return;
+                  }
+
+                  // 只发起一次 play；若夸克在 Promise 完成前收到用户暂停，
+                  // Promise 完成后再次确认暂停，避免迟到的 play 覆盖用户操作。
+                  let pausedWhilePlayPending = false;
+                  const handlePendingPause = () => {
+                    pausedWhilePlayPending = true;
+                  };
+                  video.addEventListener('pause', handlePendingPause);
+                  video
+                    .play()
+                    .then(() => {
+                      if (pausedWhilePlayPending) {
+                        video.pause();
+                      }
+                    })
+                    .catch((error) => {
+                      console.warn('[Harmony HLS] 原生播放启动失败:', error);
+                    })
+                    .finally(() => {
+                      video.removeEventListener('pause', handlePendingPause);
+                    });
+                };
+
+                video.harmonyNativeMetadataHandler = restoreNativePlayback;
+                video.addEventListener(
+                  'loadedmetadata',
+                  restoreNativePlayback,
+                  { once: true }
+                );
+
                 // 不 attach MediaSource，直接把 m3u8 交给 ArkWeb/浏览器原生播放器。
                 // currentSrc 会保留实际播放地址，供浏览器内置投屏功能读取。
                 const nativePlaybackUrl = buildNativeHlsPlaybackUrl(url);
+                video.autoplay = false;
+                video.removeAttribute('autoplay');
                 video.src = nativePlaybackUrl;
                 ensureVideoSource(video, nativePlaybackUrl);
                 video.load();
@@ -9117,9 +9213,16 @@ function PlayPageClient() {
         // 监听视频可播放事件，这时恢复播放进度更可靠
         artPlayerRef.current.on('video:canplay', () => {
           let restoredResumeTime = false;
+          const isNativeHarmonyPlayback =
+            isHarmonyOS && harmonyHlsPlaybackMode === 'native';
 
-          // 若存在需要恢复的播放进度，则跳转
-          if (resumeTimeRef.current && resumeTimeRef.current > 0) {
+          // HLS.js 在 canplay 恢复；原生 HLS 已提前在 loadedmetadata 一次性恢复，
+          // 避免夸克超级播放器接管后被迟到的 canplay 覆盖状态。
+          if (
+            !isNativeHarmonyPlayback &&
+            resumeTimeRef.current &&
+            resumeTimeRef.current > 0
+          ) {
             try {
               const duration = artPlayerRef.current.duration || 0;
               let target = resumeTimeRef.current;
@@ -9133,11 +9236,16 @@ function PlayPageClient() {
               console.warn('恢复播放进度失败:', err);
             }
           }
-          resumeTimeRef.current = null;
+          if (!isNativeHarmonyPlayback) {
+            resumeTimeRef.current = null;
+          }
 
-          const shouldResumePlaying =
-            resumePlayingAfterHlsModeSwitchRef.current;
-          resumePlayingAfterHlsModeSwitchRef.current = null;
+          const shouldResumePlaying = isNativeHarmonyPlayback
+            ? null
+            : resumePlayingAfterHlsModeSwitchRef.current;
+          if (!isNativeHarmonyPlayback) {
+            resumePlayingAfterHlsModeSwitchRef.current = null;
+          }
           if (shouldResumePlaying === false) {
             artPlayerRef.current.pause();
           } else if (shouldResumePlaying === true) {

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -98,7 +98,6 @@ import { useDownload } from '@/contexts/DownloadContext';
 declare global {
   interface HTMLVideoElement {
     hls?: any;
-    harmonyNativeMetadataHandler?: () => void;
   }
 }
 
@@ -4066,17 +4065,6 @@ function PlayPageClient() {
           artPlayerRef.current.video.hls.destroy();
         }
 
-        const cleanupVideo = artPlayerRef.current.video as
-          | HTMLVideoElement
-          | undefined;
-        if (cleanupVideo?.harmonyNativeMetadataHandler) {
-          cleanupVideo.removeEventListener(
-            'loadedmetadata',
-            cleanupVideo.harmonyNativeMetadataHandler
-          );
-          delete cleanupVideo.harmonyNativeMetadataHandler;
-        }
-
         // 销毁 ArtPlayer 实例
         artPlayerRef.current.destroy();
         artPlayerRef.current = null;
@@ -7107,9 +7095,7 @@ function PlayPageClient() {
           volume: 0.7,
           isLive: false,
           muted: false,
-          // 原生 HLS 由 loadedmetadata 中的一次性逻辑恢复播放，避免夸克
-          // 超级播放器接管后又被 Artplayer 的延迟 autoplay 覆盖暂停状态。
-          autoplay: !(isHarmonyOS && harmonyHlsPlaybackMode === 'native'),
+          autoplay: true,
           pip: true,
           autoSize: false,
           autoMini: false,
@@ -7169,91 +7155,9 @@ function PlayPageClient() {
                   delete video.hls;
                 }
 
-                // 快速换源时移除上一个源尚未触发的恢复监听，避免旧进度
-                // 在新源 loadedmetadata 后被错误写回。
-                if (video.harmonyNativeMetadataHandler) {
-                  video.removeEventListener(
-                    'loadedmetadata',
-                    video.harmonyNativeMetadataHandler
-                  );
-                }
-
-                const nativeResumeTime = resumeTimeRef.current;
-                const shouldResumeNativePlayback =
-                  resumePlayingAfterHlsModeSwitchRef.current ?? true;
-                resumeTimeRef.current = null;
-                resumePlayingAfterHlsModeSwitchRef.current = null;
-
-                const restoreNativePlayback = () => {
-                  if (
-                    video.harmonyNativeMetadataHandler !==
-                    restoreNativePlayback
-                  ) {
-                    return;
-                  }
-                  delete video.harmonyNativeMetadataHandler;
-
-                  if (nativeResumeTime && nativeResumeTime > 0) {
-                    try {
-                      const duration = Number.isFinite(video.duration)
-                        ? video.duration
-                        : 0;
-                      const target =
-                        duration && nativeResumeTime >= duration - 2
-                          ? Math.max(0, duration - 5)
-                          : nativeResumeTime;
-                      video.currentTime = target;
-                      console.log(
-                        '[Harmony HLS] loadedmetadata 恢复播放进度:',
-                        target
-                      );
-                    } catch (error) {
-                      console.warn(
-                        '[Harmony HLS] loadedmetadata 恢复进度失败:',
-                        error
-                      );
-                    }
-                  }
-
-                  if (!shouldResumeNativePlayback) {
-                    video.pause();
-                    return;
-                  }
-
-                  // 只发起一次 play；若夸克在 Promise 完成前收到用户暂停，
-                  // Promise 完成后再次确认暂停，避免迟到的 play 覆盖用户操作。
-                  let pausedWhilePlayPending = false;
-                  const handlePendingPause = () => {
-                    pausedWhilePlayPending = true;
-                  };
-                  video.addEventListener('pause', handlePendingPause);
-                  video
-                    .play()
-                    .then(() => {
-                      if (pausedWhilePlayPending) {
-                        video.pause();
-                      }
-                    })
-                    .catch((error) => {
-                      console.warn('[Harmony HLS] 原生播放启动失败:', error);
-                    })
-                    .finally(() => {
-                      video.removeEventListener('pause', handlePendingPause);
-                    });
-                };
-
-                video.harmonyNativeMetadataHandler = restoreNativePlayback;
-                video.addEventListener(
-                  'loadedmetadata',
-                  restoreNativePlayback,
-                  { once: true }
-                );
-
                 // 不 attach MediaSource，直接把 m3u8 交给 ArkWeb/浏览器原生播放器。
                 // currentSrc 会保留实际播放地址，供浏览器内置投屏功能读取。
                 const nativePlaybackUrl = buildNativeHlsPlaybackUrl(url);
-                video.autoplay = false;
-                video.removeAttribute('autoplay');
                 video.src = nativePlaybackUrl;
                 ensureVideoSource(video, nativePlaybackUrl);
                 video.load();
@@ -9213,16 +9117,9 @@ function PlayPageClient() {
         // 监听视频可播放事件，这时恢复播放进度更可靠
         artPlayerRef.current.on('video:canplay', () => {
           let restoredResumeTime = false;
-          const isNativeHarmonyPlayback =
-            isHarmonyOS && harmonyHlsPlaybackMode === 'native';
 
-          // HLS.js 在 canplay 恢复；原生 HLS 已提前在 loadedmetadata 一次性恢复，
-          // 避免夸克超级播放器接管后被迟到的 canplay 覆盖状态。
-          if (
-            !isNativeHarmonyPlayback &&
-            resumeTimeRef.current &&
-            resumeTimeRef.current > 0
-          ) {
+          // 若存在需要恢复的播放进度，则跳转
+          if (resumeTimeRef.current && resumeTimeRef.current > 0) {
             try {
               const duration = artPlayerRef.current.duration || 0;
               let target = resumeTimeRef.current;
@@ -9236,16 +9133,11 @@ function PlayPageClient() {
               console.warn('恢复播放进度失败:', err);
             }
           }
-          if (!isNativeHarmonyPlayback) {
-            resumeTimeRef.current = null;
-          }
+          resumeTimeRef.current = null;
 
-          const shouldResumePlaying = isNativeHarmonyPlayback
-            ? null
-            : resumePlayingAfterHlsModeSwitchRef.current;
-          if (!isNativeHarmonyPlayback) {
-            resumePlayingAfterHlsModeSwitchRef.current = null;
-          }
+          const shouldResumePlaying =
+            resumePlayingAfterHlsModeSwitchRef.current;
+          resumePlayingAfterHlsModeSwitchRef.current = null;
           if (shouldResumePlaying === false) {
             artPlayerRef.current.pause();
           } else if (shouldResumePlaying === true) {

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -3833,12 +3833,19 @@ function PlayPageClient() {
       // 否则 Safari 可能切回原生 HLS，和 MSE/hls.js 抢同一个播放器。
       sources.forEach((s) => s.remove());
     } else {
-      const existed = sources.some((s) => s.src === url);
-      if (!existed) {
+      const existedSource = sources.find((s) => s.src === url);
+      if (existedSource) {
+        if (isHlsLikeSource) {
+          existedSource.type = 'application/vnd.apple.mpegurl';
+        }
+      } else {
         // 移除旧的 source，保持唯一
         sources.forEach((s) => s.remove());
         const sourceEl = document.createElement('source');
         sourceEl.src = url;
+        if (isHlsLikeSource) {
+          sourceEl.type = 'application/vnd.apple.mpegurl';
+        }
         video.appendChild(sourceEl);
       }
     }
@@ -7105,9 +7112,12 @@ function PlayPageClient() {
                 kickStartHlsPlayback();
               });
 
+              // 先暴露真实 m3u8 source，供浏览器的投屏/外部播放器在
+              // hls.js 将 video.currentSrc 切换为 blob: URL 前完成识别。
+              video.hls = hls;
+              ensureVideoSource(video, url);
               hls.loadSource(url);
               hls.attachMedia(video);
-              video.hls = hls;
 
               if (isWebkit) {
                 schedulePlayerTimeout(() => {
@@ -7125,8 +7135,6 @@ function PlayPageClient() {
                   }
                 }, 3000);
               }
-
-              ensureVideoSource(video, url);
 
               // 额外确保 iOS 内联播放属性（防止全屏时使用系统播放器）
               video.setAttribute('playsinline', 'true');


### PR DESCRIPTION
## 背景

鸿蒙 ArkWeb 浏览器使用 HLS.js 播放时，MediaSource 会使 `video.currentSrc` 变为 `blob:` 地址，导致鸿蒙自带浏览器和夸克浏览器无法识别真实 HLS 源，影响内置播放器展示和投屏。

适配 UA 示例：
`Mozilla/5.0 (Phone; OpenHarmony 6.1; Android 10) ... ArkWeb/6.1.0.120 Mobile HuaweiBrowser/6.1.6.310`

## 增加的功能

- 仅在 OpenHarmony UA 且当前播放 HLS 源时显示 HLS.js 开关，不影响其他平台。
- 将开关集成到视频下方工具栏，位于“去广告”按钮右侧，样式与现有工具按钮保持一致。
- 默认开启 HLS.js，保留现有 MSE 播放、缓冲和客户端 Loader 能力。
- 关闭 HLS.js 后切换为浏览器原生 HLS，直接将 m3u8 地址赋给 `video.src`，避免 `currentSrc` 变为 `blob:`，便于浏览器读取源地址并投屏。
- 切换播放内核时恢复当前播放进度及播放/暂停状态。
- 使用 localStorage 记忆用户选择。
- 原生 HLS 模式下，工具栏“去广告”会改用服务端过滤后的 m3u8；关闭后保留代理但跳过过滤。
- 普通源仅代理播放列表，`directplay` 及原全量代理源继续代理媒体分片，子 m3u8 会继承相同策略。
- HLS.js 模式仍会在 MSE attach 前暴露带正确 MIME 类型的 m3u8 source。

## 验证

- `tsc --noEmit --incremental false` 通过。
- `git diff --check` 通过。
- 已验证给定 OpenHarmony UA 能命中鸿蒙端判断。

> 原生 HLS 的缓冲与拖动性能由 ArkWeb 媒体内核接管；日常播放建议保持默认 HLS.js，需要浏览器投屏时可关闭该开关。
