### PR TITLE
修复README中Star History图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,4 +671,4 @@ NEXT_PUBLIC_VOICE_CHAT_STRATEGY 选项解释：
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mtvpls/moontvplus&type=Date)](https://www.star-history.com/#mtvpls/moontvplus&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mtvpls/moontvplus&type=Date)](https://star-history.dera.page/#mtvpls/moontvplus&Date)


### PR DESCRIPTION
README中的Star History图表当前已失效，原因是GitHub对Stargazer接口进行了限制，导致原有数据源无法正常加载。本PR将图表切换到可用的新数据源地址，并同步更新外层链接为基于hash的URL格式，恢复图表正常显示。