### PR TITLE
fix: 小雅目录浏览支持全量翻页，修复超过100条显示不全的问题

### DIFF
--- a/src/app/api/xiaoya/browse/route.ts
+++ b/src/app/api/xiaoya/browse/route.ts
@@ -43,7 +43,18 @@ export async function GET(request: NextRequest) {
       xiaoyaConfig.Token
     );
 
-    const result = await client.listDirectory(path);
+        // 循环翻页获取全部条目（alist 单页上限100，避免大目录被截断）
+    const firstPage = await client.listDirectory(path);
+    const allContent = [...firstPage.content];
+    const total = firstPage.total || allContent.length;
+    let page = 2;
+    while (allContent.length < total && page <= 200) {
+      const next = await client.listDirectory(path, page, 100, false);
+      if (!next.content || next.content.length === 0) break;
+      allContent.push(...next.content);
+      page += 1;
+    }
+    const result = { content: allContent, total };
 
     // 过滤出文件夹和视频文件
     const videoExtensions = ['.mp4', '.mkv', '.avi', '.m3u8', '.flv', '.ts', '.mov', '.wmv', '.webm'];


### PR DESCRIPTION
## 问题
私人影库浏览小雅目录时，/api/xiaoya/browse 只调用一次 listDirectory（默认 page=1, per_page=100），
子项超过 100 个的目录只显示前 100 条，且前端无法感知还有更多数据。
实测某剧集目录有 321 个子文件夹，仅显示 100 个。

## 修复
在 browse 接口中按 total 循环翻页（每页 100，上限 200 页）取完全部条目后再返回。
实测 321 条目录可一次性完整返回。

## 兼容性
- 小目录（≤100 条）只请求一次，行为与原来完全一致
- 仅改动
服务端接口返回，不涉及前端协议变化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 目录浏览现支持分页获取更多目录条目。
  * 结果会统一筛选文件夹和视频文件，提升浏览内容的完整性与一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->