### PR TITLE
修复 OpenList 115 播放直链服务端解跳转导致 403

### DIFF
--- a/src/app/api/openlist/play/[token]/route.ts
+++ b/src/app/api/openlist/play/[token]/route.ts
@@ -129,8 +129,21 @@ export async function GET(
       );
     }
 
-    // 返回重定向到真实播放 URL
-    return NextResponse.redirect(fileResponse.data.raw_url);
+    const { resolveOpenListDirectPlayUrl } = await import(
+      '@/lib/openlist-play-url'
+    );
+    const playUrl = resolveOpenListDirectPlayUrl({
+      openListBaseUrl: openListConfig.URL,
+      filePath,
+      rawUrl: fileResponse.data.raw_url,
+      sign: fileResponse.data.sign,
+      provider: fileResponse.data.provider,
+    });
+    if (!playUrl) {
+      throw new Error('获取到的播放链接为空');
+    }
+
+    return NextResponse.redirect(playUrl);
   } catch (error) {
     console.error('获取播放链接失败:', error);
     return NextResponse.json(

--- a/src/app/api/openlist/play/route.ts
+++ b/src/app/api/openlist/play/route.ts
@@ -4,8 +4,12 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { getAuthInfoFromCookie } from '@/lib/auth';
 import { getConfig } from '@/lib/config';
-import { requireFeaturePermission } from '@/lib/permissions';
 import { OpenListClient } from '@/lib/openlist.client';
+import {
+  is115OpenListProvider,
+  resolveOpenListDirectPlayUrl,
+} from '@/lib/openlist-play-url';
+import { requireFeaturePermission } from '@/lib/permissions';
 
 export const runtime = 'nodejs';
 
@@ -95,6 +99,32 @@ async function getFinalUrl(url: string, maxRedirects = 5): Promise<string> {
   }
 
   return currentUrl;
+}
+
+async function resolveDirectFilePlayUrl(
+  openListBaseUrl: string,
+  filePath: string,
+  file: { raw_url?: string; sign?: string; provider?: string },
+  unwrapRedirects: boolean
+): Promise<string> {
+  const playUrl = resolveOpenListDirectPlayUrl({
+    openListBaseUrl,
+    filePath,
+    rawUrl: file.raw_url,
+    sign: file.sign,
+    provider: file.provider,
+  });
+  if (!playUrl) {
+    throw new Error('获取到的播放链接为空');
+  }
+  if (
+    !unwrapRedirects ||
+    is115OpenListProvider(file.provider) ||
+    playUrl !== (file.raw_url || '').trim()
+  ) {
+    return playUrl;
+  }
+  return getFinalUrl(playUrl);
 }
 
 /**
@@ -258,30 +288,23 @@ export async function GET(request: NextRequest) {
         );
       }
 
-      // 如果指定了 format=json，使用 getFinalUrl 并返回 JSON
+      const playUrl = await resolveDirectFilePlayUrl(
+        openListConfig.URL,
+        filePath,
+        fileResponse.data,
+        format === 'json'
+      );
+
       if (format === 'json') {
-        const finalUrl = await getFinalUrl(fileResponse.data.raw_url);
-
-        // 检查URL是否为空
-        if (!finalUrl || finalUrl.trim() === '') {
-          throw new Error('获取到的播放链接为空');
-        }
-
         return NextResponse.json({
-          url: finalUrl,
-          mediaType: await detectOpenListMediaType(finalUrl),
+          url: playUrl,
+          mediaType: await detectOpenListMediaType(playUrl),
           refresh14m: pathMetaResolved.refresh14m,
           category: pathMetaResolved.category,
         });
       }
 
-      // 检查URL是否为空
-      if (!fileResponse.data.raw_url || fileResponse.data.raw_url.trim() === '') {
-        throw new Error('获取到的播放链接为空');
-      }
-
-      // 默认返回重定向（用于 tvbox）
-      return NextResponse.redirect(fileResponse.data.raw_url);
+      return NextResponse.redirect(playUrl);
     }
 
     // 优先尝试视频预览流方法
@@ -353,30 +376,23 @@ export async function GET(request: NextRequest) {
         );
       }
 
-      // 如果指定了 format=json，使用 getFinalUrl 并返回 JSON
+      const playUrl = await resolveDirectFilePlayUrl(
+        openListConfig.URL,
+        filePath,
+        fileResponse.data,
+        format === 'json'
+      );
+
       if (format === 'json') {
-        const finalUrl = await getFinalUrl(fileResponse.data.raw_url);
-
-        // 检查URL是否为空
-        if (!finalUrl || finalUrl.trim() === '') {
-          throw new Error('获取到的播放链接为空');
-        }
-
         return NextResponse.json({
-          url: finalUrl,
-          mediaType: await detectOpenListMediaType(finalUrl),
+          url: playUrl,
+          mediaType: await detectOpenListMediaType(playUrl),
           refresh14m: pathMetaResolved.refresh14m,
           category: pathMetaResolved.category,
         });
       }
 
-      // 检查URL是否为空
-      if (!fileResponse.data.raw_url || fileResponse.data.raw_url.trim() === '') {
-        throw new Error('获取到的播放链接为空');
-      }
-
-      // 默认返回重定向（用于 tvbox）
-      return NextResponse.redirect(fileResponse.data.raw_url);
+      return NextResponse.redirect(playUrl);
     }
   } catch (error) {
     console.error('获取播放链接失败:', error);

--- a/src/lib/openlist-play-url.ts
+++ b/src/lib/openlist-play-url.ts
@@ -5,6 +5,8 @@
  * - filename：用于 Content-Disposition，统一使用 video.mp4
  */
 
+import { normalizeApiBaseUrl } from '@/lib/url';
+
 export function buildOpenListProxyUrl(opts: {
   token: string;
   folder: string;
@@ -13,4 +15,46 @@ export function buildOpenListProxyUrl(opts: {
 }): string {
   const query = `?folder=${encodeURIComponent(opts.folder)}&fileName=${encodeURIComponent(opts.fileName)}`;
   return `${opts.baseUrl || ''}/api/openlist/proxy/${encodeURIComponent(opts.token)}/video.mp4${query}`;
+}
+
+export function is115OpenListProvider(provider?: string): boolean {
+  const name = (provider || '').trim().toLowerCase();
+  return (
+    name === '115 cloud' ||
+    name === '115 share' ||
+    name === '115 open' ||
+    name.startsWith('115 ')
+  );
+}
+
+export function buildOpenListDownloadUrl(
+  baseURL: string,
+  filePath: string,
+  sign?: string
+): string {
+  const encodedPath = filePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  const path = encodedPath.startsWith('/') ? encodedPath : `/${encodedPath}`;
+  const url = `${normalizeApiBaseUrl(baseURL)}/d${path}`;
+  return sign ? `${url}?sign=${sign}` : url;
+}
+
+export function resolveOpenListDirectPlayUrl(opts: {
+  openListBaseUrl: string;
+  filePath: string;
+  rawUrl?: string;
+  sign?: string;
+  provider?: string;
+}): string {
+  const rawUrl = (opts.rawUrl || '').trim();
+  if (is115OpenListProvider(opts.provider) && opts.sign) {
+    return buildOpenListDownloadUrl(
+      opts.openListBaseUrl,
+      opts.filePath,
+      opts.sign
+    );
+  }
+  return rawUrl;
 }

--- a/src/lib/openlist.client.ts
+++ b/src/lib/openlist.client.ts
@@ -12,6 +12,7 @@ export interface OpenListFile {
   modified: string;
   sign?: string; // 临时下载签名
   raw_url?: string; // 完整下载链接
+  provider?: string; // OpenList 存储驱动名，如 115 Cloud
   thumb?: string;
   type: number;
   path?: string;


### PR DESCRIPTION
fix https://github.com/mtvpls/MoonTVPlus/issues/495

115 网盘播放时不再在服务端解开 CDN 直链，改为按 OpenList 驱动类型返回带 sign 的 /d/ 地址，避免 IP 绑定导致浏览器 403。这个 issue 跨域是一部分问题，也有 403 的问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能优化**
  - 优化 OpenList 文件的播放地址解析，播放请求将自动跳转至最终可用的直链。
  - 支持带签名的 115 网盘文件生成专用下载播放地址。
  - 视频预览失败或关闭预览时，仍可通过直链播放或获取播放地址。
  - 当播放地址无法解析时，将统一返回错误响应。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->